### PR TITLE
Extend orchestrator to cover all data platform services

### DIFF
--- a/CompleteDataPipeline/data-platform-springboot-microservices/pipeline/pipeline_config.yaml
+++ b/CompleteDataPipeline/data-platform-springboot-microservices/pipeline/pipeline_config.yaml
@@ -8,6 +8,15 @@ services:
   dataquality:
     base_url: http://localhost:8083
     endpoint: /api/v1/dataquality
+  datanormalization:
+    base_url: http://localhost:8084
+    endpoint: /api/v1/datanormalization
+  datastorage:
+    base_url: http://localhost:8085
+    endpoint: /api/v1/datastorage
+  dataconsumption:
+    base_url: http://localhost:8086
+    endpoint: /api/v1/dataconsumption
 http:
   timeout_seconds: 10
   retry_attempts: 2


### PR DESCRIPTION
## Summary
- extend the Python pipeline runner to call the normalization, storage, and consumption services after quality checks
- add helper utilities that enrich normalized data and summarise consumption-ready records for analytics consumers
- document the end-to-end flow and update service endpoints in the configuration so all six microservices are wired into the pipeline

## Testing
- python pipeline/run_pipeline.py --simulate --log-level DEBUG

------
https://chatgpt.com/codex/tasks/task_e_68e534a7fae483309f67de9fcff1a53e